### PR TITLE
Add example for iCloud photo download test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # qa_guru_hw_20
 
+This project contains examples of JUnit 5 tests using Selenide and REST Assured.
 
-this is homework 4 lession 20
+A new example test `ICloudDownloadTest` shows a rough approach to automate
+downloading iCloud Photos in batches of 1000. The test is disabled by default
+because it requires real iCloud credentials and manual two-factor
+authentication.

--- a/src/test/java/qaguru/ICloudDownloadTest.java
+++ b/src/test/java/qaguru/ICloudDownloadTest.java
@@ -1,0 +1,69 @@
+package qaguru;
+
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.Condition;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.codeborne.selenide.Selenide.*;
+
+/**
+ * Rough example of how automated download of iCloud photos could look.
+ * Selects photos in batches of 1000 and downloads an archive for each batch.
+ * <p>
+ * This test is disabled because it requires manual two-factor
+ * authentication and real access to iCloud Photos.
+ */
+@Disabled("Requires real iCloud credentials and manual 2FA")
+public class ICloudDownloadTest {
+
+    @Test
+    void downloadPhotosInBatches() throws Exception {
+        // Configure folder for downloads if needed
+        Configuration.downloadsFolder = "build/downloads";
+
+        // Open the iCloud Photos page
+        open("https://www.icloud.com/photos/");
+
+        // Login using credentials from system properties
+        String login = System.getProperty("icloudLogin");
+        String password = System.getProperty("icloudPassword");
+
+        // The selectors here are illustrative; actual selectors may differ
+        $("#account_name_text_field").setValue(login);
+        $("#sign-in").click();
+        $("#password_text_field").setValue(password);
+        $("#sign-in").click();
+
+        // Wait for user to enter the 2FA code manually
+        Thread.sleep(120_000); // 2 minutes should be enough
+
+        // After successful login navigate to Photos application
+        // and wait until the grid with photos is visible
+        $("div.photos-grid").shouldBe(Condition.visible, java.time.Duration.ofSeconds(30));
+
+        ElementsCollection photos = $$("div.photo-item");
+        int total = photos.size();
+
+        for (int start = 0; start < total; start += 1000) {
+            photos = $$("div.photo-item");
+            List<SelenideElement> batch = photos.stream()
+                    .skip(start)
+                    .limit(1000)
+                    .collect(Collectors.toList());
+            batch.forEach(SelenideElement::click);
+            SelenideElement downloadButton = $("button.download");
+            File archive = downloadButton.download();
+            // Optionally wait for the file to appear
+            while (!archive.exists()) {
+                Thread.sleep(1000);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- document new example test in README
- add `ICloudDownloadTest` as a draft of using Selenide to download iCloud photos

## Testing
- `gradle test` *(fails: `reqres.in` domain blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68814e588d3c832e9785be7345b7fb76